### PR TITLE
Set presets using babel-cli instead of .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["es2015", "react"]
-}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-native": "*"
   },
   "scripts": {
-    "compile": "babel lib/ -d dist/",
+    "compile": "babel --presets es2015,react lib/ -d dist/",
     "prepublish": "npm run compile"
   },
   "dependencies": {


### PR DESCRIPTION
Having `.babelrc` present with babel being a dev dependency caused an
error when trying to package use the application in React Native.

This removes `.babelrc` in favor of explicitely telling `babel-cli`
which presets to use.
